### PR TITLE
Wrong endpoint.

### DIFF
--- a/src/traits/clients.rs
+++ b/src/traits/clients.rs
@@ -195,7 +195,7 @@ where
         Popular::fetch_async(self, None, params).await
     }
 
-    /// `/api/v1/channel/:ID` endpoint.
+    /// `/api/v1/channels/:ID` endpoint.
     async fn channel(&self, id: &str, params: Option<&str>) -> Result<Channel, InvidiousError> {
         Channel::fetch_async(self, Some(id), params).await
     }

--- a/src/traits/clients.rs
+++ b/src/traits/clients.rs
@@ -64,7 +64,7 @@ where
         Popular::fetch_sync(self, None, params)
     }
 
-    /// `/api/v1/channel/:ID` endpoint.
+    /// `/api/v1/channels/:ID` endpoint.
     fn channel(&self, id: &str, params: Option<&str>) -> Result<Channel, InvidiousError> {
         Channel::fetch_sync(self, Some(id), params)
     }


### PR DESCRIPTION
before rejecting please follow the rabbit hole of calls, see that it is right. there's no such endpoint, `channel` only `channels` as your code already knows.