### PR TITLE
add continuation to ChannelVideos

### DIFF
--- a/src/structs/exposed/channel/videos.rs
+++ b/src/structs/exposed/channel/videos.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ChannelVideos {
     pub videos: Vec<CommonVideo>,
+    pub continuation: Option<String>,
 }
 
 impl PublicItems for ChannelVideos {


### PR DESCRIPTION
I don't know if there is a reason, but `continuation` is missing in `ChannelVideos`. By the way, All other structs that include the `continuation` field have it declared as an optional value (`Option<continuation>`). But I guess `continuation` must be returned? So, could we change all `Option<continuation>` to `continuation`?